### PR TITLE
Button 컴포넌트 UI 구현

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,9 +1,10 @@
 interface ButtonProps {
   text: string;
   size: "full" | "lg" | "md" | "sm";
-  type?: "default" | "inactive" | "second";
+  type: "button" | "submit";
+  status?: "default" | "inactive" | "second";
 }
-const Button = ({ text, size, type = "default" }: ButtonProps) => {
+const Button = ({ text, size, type, status = "default" }: ButtonProps) => {
   const sizeClass: { [key in ButtonProps["size"]]: string } = {
     full: "w-full h-12 text-base",
     lg: "h-12 px-8 text-base",
@@ -11,7 +12,7 @@ const Button = ({ text, size, type = "default" }: ButtonProps) => {
     sm: "h-8 px-4 text-sm"
   };
 
-  const typeClass: { [key in NonNullable<ButtonProps["type"]>]: string } = {
+  const statusClass: { [key in NonNullable<ButtonProps["status"]>]: string } = {
     default:
       "bg-main border border-main text-white-ffffff hover:bg-sub hover:text-main",
     inactive: "bg-gray-a4a1aa text-white-ffffff",
@@ -20,7 +21,8 @@ const Button = ({ text, size, type = "default" }: ButtonProps) => {
 
   return (
     <button
-      className={`${sizeClass[size]} ${typeClass[type]} rounded-md font-medium`}
+      className={`${sizeClass[size]} ${statusClass[status]} rounded-md font-medium border border-transparent`}
+      type={type}
     >
       {text}
     </button>

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,0 +1,30 @@
+interface ButtonProps {
+  text: string;
+  size: "full" | "lg" | "md" | "sm";
+  type?: "default" | "inactive" | "second";
+}
+const Button = ({ text, size, type = "default" }: ButtonProps) => {
+  const sizeClass: { [key in ButtonProps["size"]]: string } = {
+    full: "w-full h-12 text-base",
+    lg: "h-12 px-8 text-base",
+    md: "h-10 px-6 text-base",
+    sm: "h-8 px-4 text-sm"
+  };
+
+  const typeClass: { [key in NonNullable<ButtonProps["type"]>]: string } = {
+    default:
+      "bg-main border border-main text-white-ffffff hover:bg-sub hover:text-main",
+    inactive: "bg-gray-a4a1aa text-white-ffffff",
+    second: "bg-sub text-main hover:border hover:border-main"
+  };
+
+  return (
+    <button
+      className={`${sizeClass[size]} ${typeClass[type]} rounded-md font-medium`}
+    >
+      {text}
+    </button>
+  );
+};
+
+export default Button;


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [ ] 리팩터링
- [x] 기능
- [ ] 버그 수정
- [ ] 최적화
- [ ] 문서 업데이트

## 설명
### Button 컴포넌트의 UI를 제작하였습니다.
**전달 받는 props**
- `text` : 버튼 안에 나타날 텍스트이고 필수값입니다.
- `size` : 버튼의 사이즈를 설정하는 prop이고 필수값입니다. full, lg, md, sm 사이즈가 있습니다.
- `type` : 버튼의 타입을 설정하는 prop이고 기본값은 default 타입입니다. default, inactive, second 타입이 있습니다.

## 관련 티켓 및 문서

<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Closes #1 
