### PR TITLE
AuthProvider의 userCookie 객체의 빈문자열 프로퍼티 삭제

### DIFF
--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -154,7 +154,14 @@ export default function AuthProvider({ children }: AuthProviderProps) {
       );
 
       for (let item in cookies) {
-        setUserCookie((prev: UserCookieType) => ({...prev, [item]: cookies[item]}))
+        if (item === "") {
+          continue;
+        } else {
+          setUserCookie((prev: UserCookieType) => ({
+            ...prev,
+            [item]: cookies[item]
+          }));
+        }
       }
     }
 

--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -2,15 +2,12 @@ import { ReactNode, useState, useEffect, createContext } from "react";
 import axios from "axios";
 import {
   UserCookieType,
-  // JoinResponse,
-  // LoginResponse,
   JoinInfo,
   LoginInfo,
-  UserInfoToUpdate,
-  // cookieCollection
+  UserInfoToUpdate
 } from "@/types/apiTypes";
 
-const AuthContext = createContext<AuthContextType | null>(null);
+const AuthContext = createContext<AuthContextType | null | any>(null);
 
 type AuthContextType = {
   isLoggedIn: boolean;
@@ -47,9 +44,9 @@ export default function AuthProvider({ children }: AuthProviderProps) {
         "https://sp-globalnomad-api.vercel.app/2-1/users",
         joinInfo
       );
-  
+
       return res;
-    } catch(error) {
+    } catch (error) {
       return error;
     }
   }
@@ -124,17 +121,17 @@ export default function AuthProvider({ children }: AuthProviderProps) {
         userInfoToEdit,
         { headers: { Authorization: `Bearer ${userCookie.accessToken}` } }
       );
-  
+
       deleteCookie("email");
       deleteCookie("nickname");
       deleteCookie("profileImageUrl");
       deleteCookie("updatedAt");
-  
+
       document.cookie = `email=${res.data.email}`;
       document.cookie = `nickname=${res.data.nickname}`;
       document.cookie = `profileImageUrl=${res.data.profileImageUrl}`;
       document.cookie = `updatedAt=${res.data.updatedAt}`;
-  
+
       setUserCookie((prev: UserCookieType) => ({
         ...prev,
         email: res.data.email,
@@ -142,15 +139,12 @@ export default function AuthProvider({ children }: AuthProviderProps) {
         profileImageUrl: res.data.profileImageUrl,
         updatedAt: res.data.updatedAt
       }));
-  
+
       return res;
-    } catch(error) {
+    } catch (error) {
       return error;
     }
   }
-
-  //useEffect안에서만 사용
-  let getCookie;
 
   //새로고침시 userCookie값 재할당
   useEffect(() => {
@@ -159,12 +153,10 @@ export default function AuthProvider({ children }: AuthProviderProps) {
         document.cookie.split(";").map((cookie) => cookie.trim().split("="))
       );
 
-      setUserCookie(cookies);
-
-      return cookies;
+      for (let item in cookies) {
+        setUserCookie((prev: UserCookieType) => ({...prev, [item]: cookies[item]}))
+      }
     }
-
-    getCookie = getCookieInUseEffect;
 
     getCookieInUseEffect();
   }, []);
@@ -183,7 +175,7 @@ export default function AuthProvider({ children }: AuthProviderProps) {
         join,
         login,
         logout,
-        updateUserInfo,
+        updateUserInfo
       }}
     >
       {children}

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -9,28 +9,6 @@ type UserCookieType = {
   updatedAt: string | null;
 };
 
-type JoinResponse = {
-  id: number;
-  email: string;
-  nickname: string;
-  profileImageUrl: string;
-  createdAt: string;
-  updatedAt: string;
-};
-
-type LoginResponse = {
-  user: {
-    id: number;
-    email: string;
-    nickname: string;
-    profileImageUrl: string;
-    createdAt: string;
-    updatedAt: string;
-  };
-  refreshToken: string;
-  accessToken: string;
-};
-
 type JoinInfo = {
   email: string;
   nickname: string;
@@ -48,21 +26,9 @@ type UserInfoToUpdate = {
   newPassword: string;
 };
 
-type cookieCollection = {
-  id?: number | null;
-  accessToken?: string | null;
-  refreshToken?: string | null;
-  email?: string | null;
-  nickname?: string | null;
-  profileImageUrl?: string | null;
-};
-
 export type {
   UserCookieType,
-  JoinResponse,
-  LoginResponse,
   JoinInfo,
   LoginInfo,
   UserInfoToUpdate,
-  cookieCollection
 };


### PR DESCRIPTION
## 이 PR은 어떤 유형인가요?

- [ ] UI
- [x] 기능
- [x] 버그 수정
- [ ] 최적화
- [x] 리팩토링

## 설명

## 관련 티켓 및 문서
![스크린샷 2024-03-07 100345](https://github.com/Codeit-part4-team1/synamon/assets/145626840/276905b5-037f-4850-82c0-65e8b4a39886)

![image](https://github.com/Codeit-part4-team1/synamon/assets/145626840/2aad6386-fd65-4209-a8e4-ca1e8115b0e6)

**로그인 전(쿠키탭, userCookie 객체)**
![image](https://github.com/Codeit-part4-team1/synamon/assets/145626840/81c72863-b24d-4459-8bf7-5bfa2e40e26b)
![image](https://github.com/Codeit-part4-team1/synamon/assets/145626840/64509d00-f0e4-4ca1-83cd-6b74cbed502e)

**로그인 (쿠키탭, userCookie 객체)**
![image](https://github.com/Codeit-part4-team1/synamon/assets/145626840/d47a0c4b-50eb-4a22-8326-df328f966d5e)
![image](https://github.com/Codeit-part4-team1/synamon/assets/145626840/9ec6a945-2779-40ca-bfea-bfa047e7026a)

console명령어는 개인 브랜치에서 실행했습니다.