### PR TITLE
Dropdown 컴포넌트 UI 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@radix-ui/react-select": "^2.0.0",
+    "@radix-ui/react-slot": "^1.0.2",
     "axios": "^1.6.7",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,153 @@
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { ChevronDown, ChevronUp } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { pretendard } from "@/pages";
+
+const Select = SelectPrimitive.Root;
+
+const SelectGroup = SelectPrimitive.Group;
+
+const SelectValue = SelectPrimitive.Value;
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex w-full items-center justify-between rounded-[6px] border border-input dark:border-input bg-white-ffffff px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown color="#ADAEB8" className="h-4 w-4" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+));
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+));
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName;
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 max-h-96 min-w-[80px] overflow-hidden rounded-[6px] bg-white-ffffff border border-input text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-2",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
+    {...props}
+  />
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      `relative flex w-full cursor-pointer select-none items-center rounded-[4px] px-2 py-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 ${pretendard.className}`,
+      className
+    )}
+    {...props}
+  >
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton
+};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,13 @@
 import localFont from "next/font/local";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select";
 
-const pretendard = localFont({
+export const pretendard = localFont({
   src: [
     {
       path: "./fonts/PretendardVariable.woff2"
@@ -9,5 +16,33 @@ const pretendard = localFont({
 });
 
 export default function Home() {
-  return <main className={`${pretendard.className} font-sans`}></main>;
+  return (
+    <main className={`${pretendard.className} font-sans p-4`}>
+      <Select defaultValue="latest">
+        <SelectTrigger className="w-[110px] sm:w-[140px] py-2 px-3 sm:py-3 sm:px-4 text-sm sm:text-base font-medium">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem
+            className="text-sm sm:text-base font-medium focus:bg-sub"
+            value="latest"
+          >
+            최신순
+          </SelectItem>
+          <SelectItem
+            className="text-sm sm:text-base font-medium focus:bg-sub"
+            value="most_reviewed"
+          >
+            인기순
+          </SelectItem>
+          <SelectItem
+            className="text-sm sm:text-base font-medium focus:bg-sub"
+            value="price_asc"
+          >
+            가격 낮은순
+          </SelectItem>
+        </SelectContent>
+      </Select>
+    </main>
+  );
 }


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [x] UI
- [ ] 기능
- [ ] 버그 수정
- [ ] 최적화
- [ ] 리팩토링

## 설명
shadcn-ui로 main 페이지에 쓰일 Dropdown 컴포넌트 UI를 구현했습니다.

## 관련 티켓 및 문서

<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Closes #15 

## 스크린샷, 녹화
![image](https://github.com/Codeit-part4-team1/synamon/assets/96277798/28cdf6f0-83c4-4bbe-8140-4c5add2fd151)

