### PR TITLE
Searchbar 컴포넌트 UI 구현

### DIFF
--- a/src/components/common/Searchbar.tsx
+++ b/src/components/common/Searchbar.tsx
@@ -1,0 +1,27 @@
+import { IoSearchOutline } from "react-icons/io5";
+
+const Searchbar = () => {
+  return (
+    <div className="flex flex-col gap-4 md:gap-6 p-5 md:p-8 bg-sub rounded-xl border border-gray-adaeb8 mb-10">
+      <p className="text-lg md:text-xl font-bold">어떤 모임을 원하시나요?</p>
+      <form className="flex gap-2 md:gap-4">
+        <div className="flex-1 relative">
+          <IoSearchOutline className="left-3 absolute top-2/4 -translate-y-1/2 text-main text-xl md:text-2xl" />
+          <input
+            className="w-full pl-10 md:pl-12 pr-3 h-10 md:h-12 bg-white-ffffff text-base rounded-md border border-main outline-none"
+            type="text"
+            placeholder="내가 원하는 모임은"
+          />
+        </div>
+        <button
+          className="h-10 px-6 text-base md:h-12 md:px-8 bg-main rounded-md text-white-ffffff font-medium"
+          type="submit"
+        >
+          검색
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default Searchbar;


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [x] UI
- [ ] 기능
- [ ] 버그 수정
- [ ] 최적화
- [ ] 리팩토링

## 설명
메인 페이지에 있는 Searchbar 컴포넌트 UI를 구현했습니다.
기능은 데이터 가져오는 작업을 한 후에 구현할 예정입니다.

## 관련 티켓 및 문서

<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Closes #27 

## 스크린샷, 녹화
![image](https://github.com/Codeit-part4-team1/synamon/assets/96277798/14b2bedd-8217-4727-b289-2ad9502d81f9)

