### PR TITLE
Feat alert modal 구현

### DIFF
--- a/src/components/common/AlertModal.tsx
+++ b/src/components/common/AlertModal.tsx
@@ -1,0 +1,68 @@
+import React, { Dispatch, SetStateAction, useState } from "react";
+import { MdCheckCircle } from "react-icons/md";
+import Button from "./Button";
+
+type PopupProps = {
+  type: "alert" | "decide";
+  size: "md" | "sm" | "decide";
+  text: string;
+  handlerAlertModal?: any;
+  handlerDicideNo?: any;
+  handelerDicideYes?: any;
+};
+
+export default function AlertModal({
+  type,
+  size,
+  text,
+  handlerAlertModal,
+  handlerDicideNo,
+  handelerDicideYes
+}: PopupProps) {
+  const sizeClass = {
+    md: "flex flex-col gap-[60px] p-6 pt-[60px] border border-main rounded-lg mx-auto bg-white-ffffff h-[250px] w-[540px]",
+    sm: "flex flex-col gap-[50px] p-6 pt-[35px] border border-main rounded-lg mx-auto bg-white-ffffff h-[220px] w-[327px]",
+    decide:
+      "flex flex-col gap-[30px] p-6 pt-[30px] border border-main rounded-lg mx-auto bg-white-ffffff w-[298px] h-[186px]"
+  };
+
+  function checkAlert(e: React.MouseEvent<HTMLDivElement>) {
+    handlerAlertModal();
+  }
+
+  function cancel(e: React.MouseEvent<HTMLDivElement>) {
+    handlerDicideNo();
+  }
+
+  function execute(e: React.MouseEvent<HTMLDivElement>) {
+    handelerDicideYes();
+  }
+
+  return (
+    <div className="absolute flex items-center justify-center w-screen h-screen z-50 bg-gray-500 bg-opacity-50 font-bold">
+      <div className={`${sizeClass[size]}`}>
+        <div className="flex flex-col justify-center gap-1 text-center">
+          <div className="flex justify-center h-[30px]">
+            {type === "decide" && <MdCheckCircle size={25} color="#531" />}
+          </div>
+          <div className="pt-[10px] h-[25px]">{text}</div>
+        </div>
+        {(size === "md" || size === "sm") && (
+          <div onClick={checkAlert} className="text-center">
+            <Button text="확인" size="full" type="button" />
+          </div>
+        )}
+        {size === "decide" && (
+          <div className="flex felx-row gap-2 justify-center pt-[5px]">
+            <div onClick={cancel}>
+              <Button text="아니오" size="md" type="button" status="inactive" />
+            </div>
+            <div onClick={execute}>
+              <Button text="취소하기" size="md" type="button" />
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/AlertModal.tsx
+++ b/src/components/common/AlertModal.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction, useState } from "react";
+import React from "react";
 import { MdCheckCircle } from "react-icons/md";
 import Button from "./Button";
 
@@ -26,15 +26,15 @@ export default function AlertModal({
       "flex flex-col gap-[30px] p-6 pt-[30px] border border-main rounded-lg mx-auto bg-white-ffffff w-[298px] h-[186px]"
   };
 
-  function checkAlert(e: React.MouseEvent<HTMLDivElement>) {
+  function checkAlert() {
     handlerAlertModal();
   }
 
-  function cancel(e: React.MouseEvent<HTMLDivElement>) {
+  function cancel() {
     handlerDicideNo();
   }
 
-  function execute(e: React.MouseEvent<HTMLDivElement>) {
+  function execute() {
     handelerDicideYes();
   }
 


### PR DESCRIPTION
## 이 PR은 어떤 유형인가요?

- [x] UI
- [x] 기능
- [ ] 버그 수정
- [ ] 최적화
- [ ] 리팩토링

## 설명
팝업 모달 입니다.
![스크린샷 2024-03-09 133346](https://github.com/Codeit-part4-team1/synamon/assets/145626840/cdd2b54d-c316-4245-9061-f2543e92ef95)
- 버튼이 하나만 있는 모달을 사용하실 땐, type Prop에 "alert"를 전달해주시면 됩니다.
- 버튼이 두개인 모달을 사용하실 땐, type Prop에 "decide"를 전달해주시면 됩니다.
- handlerAlertModal 은 버튼이 하나만 있는 모달의 버튼 기능을 받는 Prop이며 옵셔널 입니다.
- handlerDicideNo, handelerDicideYes 는 버튼이 2개 있는 모달의 각각의 버튼 기능을 받는 Prop이며 옵셔널 입니다.
- 사용하실 때, JSX문의 2번째로 높은 레벨에서 사용해 주시고, 해당 모달은 absolute기 때문에 부모 요소의 포지션을 설정 해주시면됩니다.

## 스크린샷, 녹화
![스크린샷 2024-03-09 132710](https://github.com/Codeit-part4-team1/synamon/assets/145626840/7057a9dd-ae19-475a-a16f-3f5bf9665ae4)
![스크린샷 2024-03-09 132717](https://github.com/Codeit-part4-team1/synamon/assets/145626840/abc9be0b-1263-48c3-a10a-acd2a7818ec7)
![스크린샷 2024-03-09 132739](https://github.com/Codeit-part4-team1/synamon/assets/145626840/9e747242-a550-4828-bc54-f8482dab5b99)

