### PR TITLE
SideMenu UI 및 상세 페이지 레이아웃 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.3.4",
+    "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-slot": "^1.0.2",
     "axios": "^1.6.7",
@@ -20,9 +22,11 @@
     "next-themes": "^0.2.1",
     "react": "^18",
     "react-dom": "^18",
+    "react-hook-form": "^7.51.0",
     "react-icons": "^5.0.1",
     "tailwind-merge": "^2.2.1",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@svgr/webpack": "^8.1.0",

--- a/src/components/common/SideMenu.tsx
+++ b/src/components/common/SideMenu.tsx
@@ -1,0 +1,73 @@
+import { LuUser2 } from "react-icons/lu";
+import { TbListCheck } from "react-icons/tb";
+import { AiOutlineSetting } from "react-icons/ai";
+import { LuCalendarCheck } from "react-icons/lu";
+
+interface SideMenuProps {
+  path: string;
+}
+
+const SideMenu = ({ path }: SideMenuProps) => {
+  return (
+    <ul className="w-full md:w-44 h-fit flex md:flex-col flex-shrink-0 justify-between gap-1 md:gap-3 bg-white-ffffff md:bg-transparent border border-gray-cbc9cf md:border-none rounded-md p-2 md:p-0">
+      <li className="sm:flex-1">
+        <button
+          className={`group w-full py-1 md:py-2 px-2 sm:px-[2px] md:px-3 flex justify-center md:justify-start items-center gap-2 md:gap-3 rounded-md md:border-none ${path === "/mypage" && "border border-main bg-sub"}`}
+        >
+          <LuUser2
+            className={`hidden md:block text-xl text-gray-79747e group-hover:text-main ${path === "/mypage" && "text-main"}`}
+          />
+          <span
+            className={`text-sm md:text-base text-gray-79747e group-hover:text-main font-semibold ${path === "/mypage" && "text-main"}`}
+          >
+            내 정보
+          </span>
+        </button>
+      </li>
+      <li className="sm:flex-1">
+        <button
+          className={`group w-full py-1 md:py-2 px-2 sm:px-[2px] md:px-3 flex justify-center md:justify-start items-center gap-2 md:gap-3 rounded-md md:border-none ${path === "/history" && "border border-main bg-sub"}`}
+        >
+          <TbListCheck
+            className={`hidden md:block text-xl text-gray-79747e group-hover:text-main ${path === "/history" && "text-main"}`}
+          />
+          <span
+            className={`text-sm md:text-base text-gray-79747e group-hover:text-main font-semibold ${path === "/history" && "text-main"}`}
+          >
+            참여 내역
+          </span>
+        </button>
+      </li>
+      <li className="sm:flex-1">
+        <button
+          className={`group w-full py-1 md:py-2 px-2 sm:px-[2px] md:px-3 flex justify-center md:justify-start items-center gap-2 md:gap-3 rounded-md md:border-none ${path === "/create" && "border border-main bg-sub"}`}
+        >
+          <AiOutlineSetting
+            className={`hidden md:block text-xl text-gray-79747e group-hover:text-main ${path === "/create" && "text-main"}`}
+          />
+          <span
+            className={`text-sm md:text-base text-gray-79747e group-hover:text-main font-semibold ${path === "/create" && "text-main"}`}
+          >
+            내 모임 관리
+          </span>
+        </button>
+      </li>
+      <li className="sm:flex-1">
+        <button
+          className={`group w-full py-1 md:py-2 px-2 sm:px-[2px] md:px-3 flex justify-center md:justify-start items-center gap-2 md:gap-3 rounded-md md:border-none ${path === "/status" && "border border-main bg-sub"}`}
+        >
+          <LuCalendarCheck
+            className={`hidden md:block text-xl text-gray-79747e group-hover:text-main ${path === "/status" && "text-main"}`}
+          />
+          <span
+            className={`text-sm md:text-base text-gray-79747e group-hover:text-main font-semibold ${path === "/status" && "text-main"}`}
+          >
+            모집 현황
+          </span>
+        </button>
+      </li>
+    </ul>
+  );
+};
+
+export default SideMenu;

--- a/src/components/home/SortDropdown.tsx
+++ b/src/components/home/SortDropdown.tsx
@@ -9,7 +9,7 @@ import {
 const SortDropdown = () => {
   return (
     <Select defaultValue="latest">
-      <SelectTrigger className="w-[110px] md:w-[140px] py-2 px-3 md:py-3 md:px-4 text-sm md:text-base font-medium">
+      <SelectTrigger className="w-[110px] md:w-[140px] h-10 md:h-12 px-3 md:py-3 md:px-4 text-sm md:text-base font-medium">
         <SelectValue />
       </SelectTrigger>
       <SelectContent>

--- a/src/components/layout/BaseLayout.tsx
+++ b/src/components/layout/BaseLayout.tsx
@@ -10,7 +10,7 @@ const BaseLayout = ({ children }: BaseLayoutProps) => {
   return (
     <>
       <Header />
-      <main className="px-4 md:px-6">
+      <main className="pt-5 md:pt-7 px-4 md:px-6">
         <div className="max-w-screen-lg mx-auto mb-36 md:mb-48">{children}</div>
       </main>
       <Footer />

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -18,15 +18,17 @@ const Header = ({ user }: HeaderProps) => {
   return (
     <div className="w-full h-[60px] md:h-20 px-4 md:px-6 flex justify-center bg-white-f9f9f9 border-b-gray-dddddd border-b">
       <header className="max-w-screen-lg w-full h-full flex justify-between items-center">
-        <div className="w-[120px] h-6 relative md:w-[200px] md:h-10">
-          <Image
-            src="/images/logo-header.png"
-            alt="synamon 로고"
-            fill
-            sizes="(min-width: 768px) 200px, 120px"
-            priority
-          />
-        </div>
+        <Link href={"/"}>
+          <div className="w-[120px] h-6 relative md:w-[200px] md:h-10">
+            <Image
+              src="/images/logo-header.png"
+              alt="synamon 로고"
+              fill
+              sizes="(min-width: 768px) 200px, 120px"
+              priority
+            />
+          </div>
+        </Link>
         {user ? (
           <div className="flex gap-4 items-center">
             <div className="relative cursor-pointer">

--- a/src/components/layout/MenuLayout.tsx
+++ b/src/components/layout/MenuLayout.tsx
@@ -1,0 +1,22 @@
+import { ReactNode } from "react";
+import { useRouter } from "next/router";
+import SideMenu from "@/components/common/SideMenu";
+
+interface MenuLayoutProps {
+  children: ReactNode;
+}
+
+const MenuLayout = ({ children }: MenuLayoutProps) => {
+  const router = useRouter();
+
+  return (
+    <>
+      <div className="flex flex-col md:flex-row justify-between gap-x-7 gap-y-5">
+        <SideMenu path={router.pathname} />
+        <div className="w-full max-w-[1000px]">{children}</div>
+      </div>
+    </>
+  );
+};
+
+export default MenuLayout;

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,0 +1,180 @@
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { Slot } from "@radix-ui/react-slot";
+import {
+  Controller,
+  ControllerProps,
+  FieldPath,
+  FieldValues,
+  FormProvider,
+  useFormContext
+} from "react-hook-form";
+
+import { cn } from "@/lib/utils";
+import { Label } from "@/components/ui/label";
+
+const Form = FormProvider;
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+> = {
+  name: TName;
+};
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue
+);
+
+const FormField = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>({
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  );
+};
+
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext);
+  const itemContext = React.useContext(FormItemContext);
+  const { getFieldState, formState } = useFormContext();
+
+  const fieldState = getFieldState(fieldContext.name, formState);
+
+  if (!fieldContext) {
+    throw new Error("useFormField should be used within <FormField>");
+  }
+
+  const { id } = itemContext;
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState
+  };
+};
+
+type FormItemContextValue = {
+  id: string;
+};
+
+const FormItemContext = React.createContext<FormItemContextValue>(
+  {} as FormItemContextValue
+);
+
+const FormItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const id = React.useId();
+
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div ref={ref} className={cn(className)} {...props} />
+    </FormItemContext.Provider>
+  );
+});
+FormItem.displayName = "FormItem";
+
+const FormLabel = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({ className, ...props }, ref) => {
+  const { formItemId } = useFormField();
+
+  return (
+    <Label
+      ref={ref}
+      className={cn(className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  );
+});
+FormLabel.displayName = "FormLabel";
+
+const FormControl = React.forwardRef<
+  React.ElementRef<typeof Slot>,
+  React.ComponentPropsWithoutRef<typeof Slot>
+>(({ ...props }, ref) => {
+  const { error, formItemId, formDescriptionId, formMessageId } =
+    useFormField();
+
+  return (
+    <Slot
+      ref={ref}
+      id={formItemId}
+      aria-describedby={
+        !error
+          ? `${formDescriptionId}`
+          : `${formDescriptionId} ${formMessageId}`
+      }
+      aria-invalid={!!error}
+      {...props}
+    />
+  );
+});
+FormControl.displayName = "FormControl";
+
+const FormDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => {
+  const { formDescriptionId } = useFormField();
+
+  return (
+    <p
+      ref={ref}
+      id={formDescriptionId}
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+});
+FormDescription.displayName = "FormDescription";
+
+const FormMessage = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, children, ...props }, ref) => {
+  const { error, formMessageId } = useFormField();
+  const body = error ? String(error?.message) : children;
+
+  if (!body) {
+    return null;
+  }
+
+  return (
+    <p
+      ref={ref}
+      id={formMessageId}
+      className={cn(
+        "absolute space-y-1 text-xs md:text-sm font-medium text-destructive",
+        className
+      )}
+      {...props}
+    >
+      {body}
+    </p>
+  );
+});
+FormMessage.displayName = "FormMessage";
+
+export {
+  useFormField,
+  Form,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  FormField
+};

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -157,7 +157,7 @@ const FormMessage = React.forwardRef<
       ref={ref}
       id={formMessageId}
       className={cn(
-        "absolute space-y-1 text-xs md:text-sm font-medium text-destructive",
+        "absolute space-y-1 mt-[5px] text-xs md:text-sm font-medium md:leading-4 text-destructive",
         className
       )}
       {...props}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,25 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,24 @@
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+)
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+))
+Label.displayName = LabelPrimitive.Root.displayName
+
+export { Label }

--- a/src/pages/create.tsx
+++ b/src/pages/create.tsx
@@ -1,13 +1,10 @@
 import type { ReactElement } from "react";
 import type { NextPageWithLayout } from "@/pages/_app";
-import BaseLayout from "@/components/layout/BaseLayout";
-import MenuLayout from "@/components/layout/MenuLayout";
-
-import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-
-import Button from "@/components/common/Button";
+import { zodResolver } from "@hookform/resolvers/zod";
+import BaseLayout from "@/components/layout/BaseLayout";
+import MenuLayout from "@/components/layout/MenuLayout";
 import {
   Form,
   FormControl,
@@ -16,7 +13,7 @@ import {
   FormLabel,
   FormMessage
 } from "@/components/ui/form";
-
+import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -24,20 +21,32 @@ import {
   SelectTrigger,
   SelectValue
 } from "@/components/ui/select";
+import Button from "@/components/common/Button";
 
-import { Input } from "@/components/ui/input";
-
+const priceNumberRegex = new RegExp("^[0-9]*$");
+const priceHeadZeroRegex = new RegExp("^(0|[1-9][0-9]*)$");
 const formSchema = z.object({
-  title: z.string().min(5).max(24, {
-    // message: "Username must be at least 24 characters."
-  }),
-  category: z.string({
-    // required_error: "Please select"
-  }),
-  price: z.string(),
-  description: z.string().min(10).max(255, {
-    // message: "Username must be at least 2 characters."
-  })
+  title: z
+    .string()
+    .min(5, {
+      message: "제목은 5자 이상으로 입력해 주세요"
+    })
+    .max(24, {
+      message: "제목은 25자 미만으로 입력해 주세요"
+    }),
+  category: z.string(),
+  price: z
+    .string()
+    .regex(priceNumberRegex, { message: "숫자만 입력해 주세요" })
+    .regex(priceHeadZeroRegex, { message: "올바른 가격을 입력해 주세요" })
+    .max(7, { message: "1000만원 미만으로 입력해 주세요" }),
+  description: z
+    .string()
+    .min(10, { message: "설명은 10자 이상으로 입력해 주세요" })
+    .max(255, {
+      message: "설명은 256자 미만으로 입력해 주세요"
+    }),
+  address: z.string()
 });
 
 function onSubmit(values: z.infer<typeof formSchema>) {
@@ -52,7 +61,9 @@ const CreatePage: NextPageWithLayout = () => {
     defaultValues: {
       title: "",
       category: "문화 · 예술",
-      price: "0"
+      price: "",
+      description: "",
+      address: ""
     }
   });
   return (
@@ -60,10 +71,10 @@ const CreatePage: NextPageWithLayout = () => {
       <p className="text-2xl md:text-3xl font-bold mb-5 md:mb-8">모임 등록</p>
       <Form {...form}>
         <form
-          className="flex flex-col gap-y-4 md:gap-y-6"
+          className="flex flex-col gap-y-5 md:gap-y-6"
           onSubmit={form.handleSubmit(onSubmit)}
         >
-          <div className="flex flex-col md:flex-row gap-x-4 gap-y-4 md:gap-y-6">
+          <div className="flex flex-col md:flex-row gap-x-4 gap-y-5 md:gap-y-6">
             <FormField
               control={form.control}
               name="title"
@@ -74,8 +85,8 @@ const CreatePage: NextPageWithLayout = () => {
                   </FormLabel>
                   <FormControl>
                     <Input
-                      placeholder="제목을 입력해주세요"
                       className="h-10 md:h-12 px-3 md:px-4 mt-1 md:mt-2 text-sm md:text-base bg-white-ffffff border-gray-a4a1aa"
+                      placeholder="제목을 입력해 주세요"
                       {...field}
                     />
                   </FormControl>
@@ -148,14 +159,14 @@ const CreatePage: NextPageWithLayout = () => {
                 control={form.control}
                 name="price"
                 render={({ field }) => (
-                  <FormItem className="flex-1 md:w-32">
+                  <FormItem className="relative flex-1 md:w-32">
                     <FormLabel className="text-lg md:text-xl font-semibold">
                       가격 (원)
                     </FormLabel>
                     <FormControl>
                       <Input
-                        placeholder="가격"
                         className="h-10 md:h-12 px-3 md:px-4 mt-1 md:mt-2 text-sm md:text-base bg-white-ffffff border-gray-a4a1aa"
+                        placeholder="가격"
                         {...field}
                       />
                     </FormControl>
@@ -165,26 +176,73 @@ const CreatePage: NextPageWithLayout = () => {
               />
             </div>
           </div>
-          <div className="mt-0">
+          <div>
             <FormField
               control={form.control}
               name="description"
               render={({ field }) => (
-                <FormItem className="flex-1">
+                <FormItem className="h-fit">
                   <FormLabel className="text-lg md:text-xl font-semibold">
                     설명
                   </FormLabel>
                   <FormControl>
                     <textarea
                       className="w-full h-52 py-2 md:py-3 px-3 md:px-4 mt-1 md:mt-2 text-sm md:text-base bg-white-ffffff border border-gray-a4a1aa rounded-md outline-none resize-none placeholder:text-gray-adaeb8"
-                      placeholder="설명을 입력해주세요"
+                      placeholder="설명을 입력해 주세요"
                       {...field}
                     ></textarea>
                   </FormControl>
-                  <FormMessage />
+                  <FormMessage className="mt-0 leading-none md:leading-none" />
                 </FormItem>
               )}
             />
+          </div>
+          <div className="max-w-[700px]">
+            <div>
+              <FormField
+                control={form.control}
+                name="address"
+                render={({ field }) => (
+                  <FormItem className="flex-1">
+                    <FormLabel className="text-lg md:text-xl font-semibold">
+                      주소
+                    </FormLabel>
+                    <div className="flex flex-col gap-2">
+                      <div className="flex items-end gap-2 md:gap-4">
+                        <FormControl>
+                          <Input
+                            className="h-10 md:h-12 px-3 md:px-4 mt-1 md:mt-2 text-sm md:text-base bg-white-ffffff border-gray-a4a1aa"
+                            placeholder="우편번호"
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                        <Button
+                          text="주소 검색"
+                          type="button"
+                          className="flex-shrink-0 h-10 px-6 text-base md:h-12 md:px-8"
+                        />
+                      </div>
+                      <FormControl>
+                        <Input
+                          className="h-10 md:h-12 px-3 md:px-4 mt-1 md:mt-2 text-sm md:text-base bg-white-ffffff border-gray-a4a1aa"
+                          placeholder="기본 주소를 입력해주세요"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormControl>
+                        <Input
+                          className="h-10 md:h-12 px-3 md:px-4 mt-1 md:mt-2 text-sm md:text-base bg-white-ffffff border-gray-a4a1aa"
+                          placeholder="상세 주소를 입력해주세요"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </div>
+                  </FormItem>
+                )}
+              />
+            </div>
           </div>
           <Button
             text="등록하기"

--- a/src/pages/create.tsx
+++ b/src/pages/create.tsx
@@ -1,0 +1,208 @@
+import type { ReactElement } from "react";
+import type { NextPageWithLayout } from "@/pages/_app";
+import BaseLayout from "@/components/layout/BaseLayout";
+import MenuLayout from "@/components/layout/MenuLayout";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+import Button from "@/components/common/Button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage
+} from "@/components/ui/form";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select";
+
+import { Input } from "@/components/ui/input";
+
+const formSchema = z.object({
+  title: z.string().min(5).max(24, {
+    // message: "Username must be at least 24 characters."
+  }),
+  category: z.string({
+    // required_error: "Please select"
+  }),
+  price: z.string(),
+  description: z.string().min(10).max(255, {
+    // message: "Username must be at least 2 characters."
+  })
+});
+
+function onSubmit(values: z.infer<typeof formSchema>) {
+  // Do something with the form values.
+  // ✅ This will be type-safe and validated.
+  console.log(values);
+}
+
+const CreatePage: NextPageWithLayout = () => {
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      title: "",
+      category: "문화 · 예술",
+      price: "0"
+    }
+  });
+  return (
+    <>
+      <p className="text-2xl md:text-3xl font-bold mb-5 md:mb-8">모임 등록</p>
+      <Form {...form}>
+        <form
+          className="flex flex-col gap-y-4 md:gap-y-6"
+          onSubmit={form.handleSubmit(onSubmit)}
+        >
+          <div className="flex flex-col md:flex-row gap-x-4 gap-y-4 md:gap-y-6">
+            <FormField
+              control={form.control}
+              name="title"
+              render={({ field }) => (
+                <FormItem className="flex-1">
+                  <FormLabel className="text-lg md:text-xl font-semibold">
+                    제목
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="제목을 입력해주세요"
+                      className="h-10 md:h-12 px-3 md:px-4 mt-1 md:mt-2 text-sm md:text-base bg-white-ffffff border-gray-a4a1aa"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <div className="flex gap-x-4">
+              <FormField
+                control={form.control}
+                name="category"
+                render={({ field }) => (
+                  <FormItem className="flex-1">
+                    <FormLabel className="text-lg md:text-xl font-semibold">
+                      카테고리
+                    </FormLabel>
+                    <Select
+                      onValueChange={field.onChange}
+                      defaultValue="문화 · 예술"
+                    >
+                      <FormControl>
+                        <SelectTrigger className="w-full md:w-[124px] h-10 md:h-12 px-3 md:py-3 md:px-4 mt-1 md:mt-2 text-sm md:text-base font-medium">
+                          <SelectValue />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem
+                          className="text-sm md:text-base font-medium focus:bg-sub"
+                          value="문화 · 예술"
+                        >
+                          문화 · 예술
+                        </SelectItem>
+                        <SelectItem
+                          className="text-sm md:text-base font-medium focus:bg-sub"
+                          value="식음료"
+                        >
+                          식음료
+                        </SelectItem>
+                        <SelectItem
+                          className="text-sm md:text-base font-medium focus:bg-sub"
+                          value="스포츠"
+                        >
+                          스포츠
+                        </SelectItem>
+                        <SelectItem
+                          className="text-sm md:text-base font-medium focus:bg-sub"
+                          value="투어"
+                        >
+                          투어
+                        </SelectItem>
+                        <SelectItem
+                          className="text-sm md:text-base font-medium focus:bg-sub"
+                          value="관광"
+                        >
+                          관광
+                        </SelectItem>
+                        <SelectItem
+                          className="text-sm md:text-base font-medium focus:bg-sub"
+                          value="웰빙"
+                        >
+                          웰빙
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="price"
+                render={({ field }) => (
+                  <FormItem className="flex-1 md:w-32">
+                    <FormLabel className="text-lg md:text-xl font-semibold">
+                      가격 (원)
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="가격"
+                        className="h-10 md:h-12 px-3 md:px-4 mt-1 md:mt-2 text-sm md:text-base bg-white-ffffff border-gray-a4a1aa"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+          </div>
+          <div className="mt-0">
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem className="flex-1">
+                  <FormLabel className="text-lg md:text-xl font-semibold">
+                    설명
+                  </FormLabel>
+                  <FormControl>
+                    <textarea
+                      className="w-full h-52 py-2 md:py-3 px-3 md:px-4 mt-1 md:mt-2 text-sm md:text-base bg-white-ffffff border border-gray-a4a1aa rounded-md outline-none resize-none placeholder:text-gray-adaeb8"
+                      placeholder="설명을 입력해주세요"
+                      {...field}
+                    ></textarea>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+          <Button
+            text="등록하기"
+            className="w-full md:w-96 h-12 mx-auto mt-8"
+            type="submit"
+          ></Button>
+        </form>
+      </Form>
+    </>
+  );
+};
+
+CreatePage.getLayout = function getLayout(page: ReactElement) {
+  return (
+    <BaseLayout>
+      <MenuLayout>{page}</MenuLayout>
+    </BaseLayout>
+  );
+};
+
+export default CreatePage;


### PR DESCRIPTION
<!--
 풀 리퀘스트에 대한 신속한 검토/응답을 위해, 이미 리뷰나 코멘트를 받았다면 추가 커밋을 강제 푸시하지 마세요.
풀 리퀘스트를 제출하기 전에 다음을 확인해 주세요:

👷‍♀️ 작은 PR을 만들어 주세요.
📝 설명이 명확한 커밋 메시지를 사용하세요.
📗 관련된 문서를 업데이트하고 필요한 스크린샷을 포함하세요.
-->

## 이 PR은 어떤 유형인가요?

- [x] UI
- [ ] 기능
- [ ] 버그 수정
- [ ] 최적화
- [ ] 리팩토링

## 설명
1. 사이드 메뉴 UI를 구현했습니다.
2. 상세 페이지(내 정보, 참여 내역, 내 모임 관리, 모집 현황) 레이아웃을 구현했습니다.
3. create 페이지 일부분만 구현하였습니다.

## 관련 티켓 및 문서

<!--
풀 리퀘스트가 관련되거나 문제를 해결하는 경우, 아래에 포함해 주세요. [Github의 문제 연결 가이드](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)를 따르고 싶습니다.).

예를 들어, "closes #1234"라는 텍스트가 현재 풀 리퀘스트와 1234번 이슈를 연결하고, 풀 리퀘스트가 병합되면 Github가 자동으로 이슈를 닫습니다.
-->

- Closes #51 

## 스크린샷, 녹화
![image](https://github.com/Codeit-part4-team1/synamon/assets/96277798/70685dd7-d8ca-4a26-a6a7-492521d4e3f1)
![image](https://github.com/Codeit-part4-team1/synamon/assets/96277798/e9fe2b92-e0a6-41d8-949c-085513a4c967)

